### PR TITLE
Change repository url from SSH to HTTPS

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com:heremaps/harp-terrain-datasource.git"
+    "url": "https://github.com/heremaps/harp-terrain-datasource.git"
   },
   "files": [
     "src",


### PR DESCRIPTION
Using HTTPS allows users to clone the repository using tools like OSS Review Toolkit without authentication.

